### PR TITLE
Properly impoort rank_zero from pytorch_lightning

### DIFF
--- a/cldm/logger.py
+++ b/cldm/logger.py
@@ -5,7 +5,7 @@ import torch
 import torchvision
 from PIL import Image
 from pytorch_lightning.callbacks import Callback
-from pytorch_lightning.utilities.distributed import rank_zero_only
+from pytorch_lightning.utilities.rank_zero import rank_zero_only
 
 
 class ImageLogger(Callback):

--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -17,7 +17,7 @@ from functools import partial
 import itertools
 from tqdm import tqdm
 from torchvision.utils import make_grid
-from pytorch_lightning.utilities.distributed import rank_zero_only
+from pytorch_lightning.utilities.rank_zero import rank_zero_only
 from omegaconf import ListConfig
 
 from ldm.util import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config


### PR DESCRIPTION
Starting from version [1.8.0.post1 released on November 2nd 2022](https://stackoverflow.com/a/74301681/6645624) the correct way to import is:
```python
from pytorch_lightning.utilities.rank_zero import rank_zero
```
istead of
```python
from pytorch_lightning.utilities.distributed import rank_zero
```