### PR TITLE
opencv-python-headless

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
   - pip:
       - gradio==3.16.2
       - albumentations==1.3.0
-      - opencv-contrib-python==4.3.0.36
+      - opencv-contrib-python-headless==4.3.0.36
       - imageio==2.9.0
       - imageio-ffmpeg==0.4.2
       - pytorch-lightning==1.5.0


### PR DESCRIPTION
This replaces the opencv package with a headless variant, to avoid dependency on libglib2, libgl1 etc. Ref #495